### PR TITLE
feat: Implement backend for resetting user password

### DIFF
--- a/api/templates/user_password_reset.html
+++ b/api/templates/user_password_reset.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Action Required</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #f4f6f8;
+        margin: 0;
+        padding: 20px;
+        color: #333;
+      }
+
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        background: #ffffff;
+        border-radius: 14px;
+        overflow: hidden;
+        box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
+      }
+
+      .top-bar {
+        height: 10px;
+        background: linear-gradient(90deg, #1e3a8a 0%, #7a1f2b 100%);
+      }
+
+      .content-wrapper {
+        padding: 40px 32px;
+      }
+
+      .logo {
+        display: block;
+        margin: 0 auto 25px;
+        width: 170px;
+      }
+
+      .headline {
+        text-align: center;
+        font-size: 26px;
+        font-weight: bold;
+        letter-spacing: 0.5px;
+        margin-bottom: 6px;
+        color: #111;
+      }
+
+      .tagline {
+        text-align: center;
+        font-size: 13px;
+        color: #7a1f2b;
+        margin-bottom: 28px;
+        letter-spacing: 1px;
+      }
+
+      p {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #555;
+        margin: 12px 0;
+      }
+
+      .section {
+        margin: 20px 0;
+      }
+
+      .notice {
+        background: #fdf4f5;
+        border-left: 6px solid #7a1f2b;
+        padding: 16px;
+        border-radius: 8px;
+        margin: 28px 0;
+        font-size: 14px;
+      }
+
+      .notice strong {
+        color: #7a1f2b;
+      }
+
+      .btn-container {
+        text-align: center;
+        margin: 40px 0;
+      }
+
+      .reset-btn {
+        display: inline-block;
+        padding: 15px 42px;
+        font-size: 16px;
+        font-weight: bold;
+        text-decoration: none;
+        border-radius: 8px;
+        color: #ffffff !important;
+        background: linear-gradient(90deg, #1e3a8a, #7a1f2b);
+        border: none;
+        width: 100%;
+        box-sizing: border-box;
+      }
+
+      .divider {
+        height: 1px;
+        background: #eee;
+        margin: 35px 0;
+      }
+
+      .footer {
+        text-align: center;
+        font-size: 13px;
+        color: #888;
+        line-height: 1.6;
+      }
+
+      .footer strong {
+        color: #7a1f2b;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="container">
+      <div class="top-bar"></div>
+
+      <div class="content-wrapper">
+        <img
+          src="https://th.bing.com/th/id/OIP.y7It5uZvqs0iL8v-OUwNrAHaHa?rs=1&pid=ImgDetMain"
+          class="logo"
+        />
+
+        <div class="headline">Password Update Requested</div>
+        <div class="tagline">VERIFY, SECURE, CONTINUE</div>
+
+        <div class="section">
+          <p>
+            Someone initiated a password change for your account. If that was
+            you, you’re one step away from getting back in.
+          </p>
+
+          <p>
+            Use the secure link below to set a new password. For security
+            reasons, access will expire shortly.
+          </p>
+        </div>
+
+        <div class="btn-container">
+          <a href="{{ reset_url }}" class="reset-btn"> Password Reset Link </a>
+        </div>
+
+        <div class="notice">
+          <strong>Unexpected activity?</strong><br />
+          If this wasn’t you, you can ignore this message—no changes will be
+          applied and your account stays secure.
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="footer">
+          <p>
+            This link is uniquely generated for you. Do not share it.<br />
+            Need assistance? Our support team is ready to help.
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/api/urls/authentication.py
+++ b/api/urls/authentication.py
@@ -2,13 +2,15 @@ from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView
 from api.views import(
     SignUpEndpoint,
-    SignInEndPoint
+    SignInEndPoint,
+    ForgotPasswordEndpoint,
+    ResetPasswordEndpoint
 )
-
 
 urlpatterns = [
     path('user/sign-up/', SignUpEndpoint().as_view()),
     path('user/sign-in/', SignInEndPoint().as_view()),
     path("token/refresh/", TokenRefreshView.as_view()),
-
+    path('user/forgot-password/', ForgotPasswordEndpoint.as_view()),
+    path('user/reset-password/', ResetPasswordEndpoint.as_view()),
 ]

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -3,3 +3,5 @@ from .user import *
 from .workspace import *
 from .project import *
 from .profile import *
+
+from .user_password_reset import ForgotPasswordEndpoint, ResetPasswordEndpoint

--- a/api/views/user_password_reset.py
+++ b/api/views/user_password_reset.py
@@ -1,0 +1,96 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from django.contrib.auth.hashers import make_password
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.encoding import force_bytes, force_str
+from django.contrib.auth.tokens import default_token_generator
+from django.conf import settings
+from db.models import User
+from api.utils import send_otp
+
+FRONTEND_BASE_URL = getattr(settings, "FRONTEND_BASE_URL", "http://localhost:3011")
+
+# ForgotPasswordEndpoint sends a reset email to the user with a generated token.
+class ForgotPasswordEndpoint(APIView):
+    def post(self, request):
+        # check email exists
+        email = request.data.get("email", "").strip()
+        if not email:
+            return Response({"message": "Email is required.", "statusCode": 400})
+
+        try:
+            # get user corresponding to the email
+            user = User.objects.get(email=email)
+
+            # generate token and reset URL
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
+            token = default_token_generator.make_token(user)
+            reset_url = f"{FRONTEND_BASE_URL}/reset-password?uid={uid}&token={token}"
+
+            # send email
+            send_otp(
+                email_subject="Reset Your CS Pro Plane Password",
+                email_template="user_password_reset.html",
+                recipient_email=user.email,
+                context={
+                    "reset_url": reset_url,
+                    "recipient_email": user.email,
+                },
+            )
+        # don't do anything if email does not correspond to a user
+        except User.DoesNotExist:
+            pass
+        except Exception as e:
+            print("ForgotPasswordEndpoint error:", e)
+
+        return Response({
+            "message": "If an account with that email exists, a reset link has been sent.",
+            "statusCode": 200,
+        })
+
+# ResetPasswordEndpoint sets a new password for a user.
+class ResetPasswordEndpoint(APIView):
+    def post(self, request):
+        # check that UID, token, and new password exists
+        uid = request.data.get("uid", "")
+        token = request.data.get("token", "")
+        new_password = request.data.get("new_password", "")
+        if not uid or not token or not new_password:
+            return Response({
+                "message": "uid, token, and new_password are all required.",
+                "statusCode": 400,
+            })
+
+        # get user
+        try:
+            user_pk = force_str(urlsafe_base64_decode(uid))
+            user = User.objects.get(pk=user_pk)
+        except (User.DoesNotExist, ValueError, OverflowError, Exception) as e:
+            print("ResetPasswordEndpoint - user lookup error:", e)
+            return Response({
+                "message": "Invalid or expired reset link.",
+                "statusCode": 400,
+            })
+
+        # validate token
+        if not default_token_generator.check_token(user, token):
+            return Response({
+                "message": "Reset link is invalid or has expired.",
+                "statusCode": 400,
+            })
+
+        # validate new password length
+        if len(new_password) < 6:
+            return Response({
+                "message": "Password must be at least 6 characters.",
+                "statusCode": 400,
+            })
+
+        # set and save password
+        user.password = make_password(new_password)
+        user.save()
+
+        return Response({
+            "message": "Password reset successfully. You can now sign in.",
+            "statusCode": 200,
+        })


### PR DESCRIPTION
### Summary

Implemented backend functionality for resetting password. Closes #45 

### Rationale

Users will now be able to access these endpoints to reset their password.

### Changes Made

- Added a new email template.
- Added logic for password reset.

#### Sent Email Template

<img width="428" height="562" alt="Screenshot 2026-04-20 at 9 18 14 PM" src="https://github.com/user-attachments/assets/89ccc651-065a-410b-8717-e3aa6a335a72" />
