### PR TITLE
feat(api): implement backend endpoints for Reset Password flow

### DIFF
--- a/Plane/settings.py
+++ b/Plane/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 from pathlib import Path
 from datetime import timedelta
 import os
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -21,12 +22,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-yt+&3l0nrs8ntog!t4uhv_((e$4i_j6@@*bpe@27x*kp=)b-jx'
+SECRET_KEY = "django-insecure-yt+&3l0nrs8ntog!t4uhv_((e$4i_j6@@*bpe@27x*kp=)b-jx"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 CORS_ALLOW_ALL_ORIGINS = True
 
@@ -34,54 +35,53 @@ CORS_ALLOW_ALL_ORIGINS = True
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'corsheaders',
-    'djoser',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "corsheaders",
+    "djoser",
     "rest_framework_simplejwt.token_blacklist",
-    'drf_yasg',
-    'db',
-    'api',
-    'team'
-    
+    "drf_yasg",
+    "db",
+    "api",
+    "team",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware'
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
 ]
 
 
-ROOT_URLCONF = 'Plane.urls'
+ROOT_URLCONF = "Plane.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'Plane.wsgi.application'
+WSGI_APPLICATION = "Plane.wsgi.application"
 
 
 # Database
@@ -94,7 +94,7 @@ WSGI_APPLICATION = 'Plane.wsgi.application'
 #     }
 # }
 
-#dev
+# dev
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -106,25 +106,22 @@ DATABASES = {
 }
 
 REST_FRAMEWORK = {
-    
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-         
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.AllowAny',
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.AllowAny",
     ],
-  
 }
 
 #
 SIMPLE_JWT = {
     # "ACCESS_TOKEN_LIFETIME": timedelta(minutes=10080),
     # "REFRESH_TOKEN_LIFETIME": timedelta(days=43200),
-     "ACCESS_TOKEN_LIFETIME": timedelta(days = 10),
+    "ACCESS_TOKEN_LIFETIME": timedelta(days=10),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=30),
-     'ACCESS_TOKEN_COOKIE': 'accessToken',
-    'REFRESH_TOKEN_COOKIE': 'refreshToken',
+    "ACCESS_TOKEN_COOKIE": "accessToken",
+    "REFRESH_TOKEN_COOKIE": "refreshToken",
     "ROTATE_REFRESH_TOKENS": False,
     "BLACKLIST_AFTER_ROTATION": False,
     "UPDATE_LAST_LOGIN": False,
@@ -136,23 +133,18 @@ SIMPLE_JWT = {
     "JSON_ENCODER": None,
     "JWK_URL": None,
     "LEEWAY": 0,
-
     "AUTH_HEADER_TYPES": ("Bearer",),
     "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
     "USER_ID_FIELD": "id",
     "USER_ID_CLAIM": "user_id",
     "USER_AUTHENTICATION_RULE": "rest_framework_simplejwt.authentication.default_user_authentication_rule",
-
     "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
     "TOKEN_TYPE_CLAIM": "token_type",
     "TOKEN_USER_CLASS": "rest_framework_simplejwt.models.TokenUser",
-
     "JTI_CLAIM": "jti",
-
     "SLIDING_TOKEN_REFRESH_EXP_CLAIM": "refresh_exp",
     "SLIDING_TOKEN_LIFETIME": timedelta(minutes=5),
     "SLIDING_TOKEN_REFRESH_LIFETIME": timedelta(days=1),
-
     "TOKEN_OBTAIN_SERIALIZER": "rest_framework_simplejwt.serializers.TokenObtainPairSerializer",
     "TOKEN_REFRESH_SERIALIZER": "rest_framework_simplejwt.serializers.TokenRefreshSerializer",
     "TOKEN_VERIFY_SERIALIZER": "rest_framework_simplejwt.serializers.TokenVerifySerializer",
@@ -177,16 +169,16 @@ JWT_SECRET = "CS-ProPlane-#@123!"
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -194,9 +186,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -207,22 +199,22 @@ AUTH_USER_MODEL = "db.User"
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_URL = "static/"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-MEDIA_URL = '/media/'  # URL to access media files
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media') 
+MEDIA_URL = "/media/"  # URL to access media files
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 # Added by Fidha Naushad on 11th May 2024
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "smtp.gmail.com"
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = 'csproplane@gmail.com'
-EMAIL_HOST_PASSWORD = 'qkxxhhpdlwxzqkku'
+EMAIL_HOST_USER = "csproplane@gmail.com"
+EMAIL_HOST_PASSWORD = "qkxxhhpdlwxzqkku"
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False

--- a/api/templates/reset_user_password.html
+++ b/api/templates/reset_user_password.html
@@ -1,0 +1,141 @@
+{% load static %}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reset Password</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        font-family: Arial, sans-serif;
+        background-color: #f3f3f3;
+        color: #333333;
+      }
+
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        background-color: #ffffff;
+        border-radius: 10px;
+        padding: 24px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.08);
+      }
+
+      .logo {
+        display: block;
+        width: 84px;
+        height: 84px;
+        margin: 0 auto 16px;
+        border-radius: 50%;
+        object-fit: cover;
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        text-align: center;
+        font-size: 24px;
+        color: #1b1f3b;
+      }
+
+      p {
+        margin: 0 0 14px;
+        line-height: 1.6;
+        font-size: 15px;
+      }
+
+      .intro {
+        text-align: center;
+        color: #4b5563;
+      }
+
+      .button-wrap {
+        text-align: center;
+        margin: 28px 0;
+      }
+
+      .reset-button {
+        display: inline-block;
+        background-color: #007bff;
+        color: #ffffff !important;
+        text-decoration: none;
+        padding: 12px 24px;
+        font-size: 15px;
+        border-radius: 6px;
+        font-weight: 600;
+      }
+
+      .fallback-link {
+        word-break: break-word;
+        font-size: 13px;
+        color: #2563eb;
+      }
+
+      .footer {
+        margin-top: 24px;
+        text-align: center;
+        font-size: 12px;
+        color: #6b7280;
+      }
+
+      .notice {
+        border-left: 3px solid #007bff;
+        background: #f8fbff;
+        padding: 12px;
+        border-radius: 4px;
+        font-size: 13px;
+        color: #374151;
+      }
+
+      @media (max-width: 640px) {
+        body {
+          padding: 12px;
+        }
+
+        .container {
+          padding: 18px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <img
+        src="https://th.bing.com/th/id/OIP.y7It5uZvqs0iL8v-OUwNrAHaHa?rs=1&pid=ImgDetMain"
+        alt="CS Pro Plane"
+        class="logo"
+      />
+
+      <h1>Reset Your Password</h1>
+      <p class="intro">
+        We received a request to reset the password for your CS Pro Plane
+        account.
+      </p>
+
+      <p>
+        Click the button below to choose a new password. This link will expire
+        for security reasons.
+      </p>
+
+      <div class="button-wrap">
+        <a href="{{ reset_url }}" class="reset-button">Reset Password</a>
+      </div>
+
+      <p>
+        If the button does not work, copy and paste this link into your browser:
+      </p>
+      <p class="fallback-link">{{ reset_url }}</p>
+
+      <div class="notice">
+        If you did not request a password reset, you can safely ignore this
+        email. Your current password will remain unchanged.
+      </div>
+
+      <p class="footer">
+        This email was sent to {{ recipient_email }}. Please delete it if you
+        are not the intended recipient.
+      </p>
+    </div>
+  </body>
+</html>

--- a/api/urls/authentication.py
+++ b/api/urls/authentication.py
@@ -2,7 +2,9 @@ from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView
 from api.views import(
     SignUpEndpoint,
-    SignInEndPoint
+    SignInEndPoint,
+    ForgotPasswordEndpoint,
+    ResetPasswordEndpoint
 )
 
 
@@ -10,5 +12,6 @@ urlpatterns = [
     path('user/sign-up/', SignUpEndpoint().as_view()),
     path('user/sign-in/', SignInEndPoint().as_view()),
     path("token/refresh/", TokenRefreshView.as_view()),
-
+    path('user/forgot-password/', ForgotPasswordEndpoint.as_view()),
+    path('user/reset-password/', ResetPasswordEndpoint.as_view()),
 ]

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -3,3 +3,4 @@ from .user import *
 from .workspace import *
 from .project import *
 from .profile import *
+from .reset_user_password import *

--- a/api/views/reset_user_password.py
+++ b/api/views/reset_user_password.py
@@ -1,0 +1,111 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from django.contrib.auth.hashers import make_password
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.encoding import force_bytes, force_str
+from django.contrib.auth.tokens import default_token_generator
+from django.conf import settings
+from db.models import User
+from api.utils import send_otp
+
+# Base URL for the frontend application
+FRONTEND_BASE_URL = getattr(settings, "FRONTEND_BASE_URL", "http://localhost:3011")
+
+
+# ForgotPasswordEndpoint sends a generated token to the user's email
+class ForgotPasswordEndpoint(APIView):
+    def post(self, request):
+        # validate email exists
+        email = request.data.get("email", "").strip()
+        if not email:
+            return Response({"message": "Email is required.", "statusCode": 400})
+
+        try:
+            # get user by email
+            user = User.objects.get(email=email)
+
+            # generates uid and token for password reset link
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
+            token = default_token_generator.make_token(user)
+            reset_url = f"{FRONTEND_BASE_URL}/reset-password?uid={uid}&token={token}"
+
+            # sends password reset email
+            send_otp(
+                email_subject="Reset Your CS Pro Plane Password",
+                email_template="reset_user_password.html",
+                recipient_email=user.email,
+                context={
+                    "reset_url": reset_url,
+                    "recipient_email": user.email,
+                },
+            )
+        # if email doesn't exist, do nothing
+        except User.DoesNotExist:
+            pass
+        except Exception as e:
+            print("ForgotPasswordEndpoint error:", e)
+
+        return Response(
+            {
+                "message": "If an account with that email exists, a reset link has been sent.",
+                "statusCode": 200,
+            }
+        )
+
+
+# ResetPasswordEndpoint validates the token and resets the user's password
+class ResetPasswordEndpoint(APIView):
+    def post(self, request):
+        # validate uid, token, and new_password are provided
+        uid = request.data.get("uid", "")
+        token = request.data.get("token", "")
+        new_password = request.data.get("new_password", "")
+        if not uid or not token or not new_password:
+            return Response(
+                {
+                    "message": "uid, token, and new_password are all required.",
+                    "statusCode": 400,
+                }
+            )
+
+        # lookup user by uid
+        try:
+            user_pk = force_str(urlsafe_base64_decode(uid))
+            user = User.objects.get(pk=user_pk)
+        except (User.DoesNotExist, ValueError, OverflowError, Exception) as e:
+            print("ResetPasswordEndpoint - user lookup error:", e)
+            return Response(
+                {
+                    "message": "Invalid or expired reset link.",
+                    "statusCode": 400,
+                }
+            )
+
+        # validate the token is valid for the user
+        if not default_token_generator.check_token(user, token):
+            return Response(
+                {
+                    "message": "Reset link is invalid or has expired.",
+                    "statusCode": 400,
+                }
+            )
+
+        # validate password length
+        if len(new_password) < 6:
+            return Response(
+                {
+                    "message": "Password must be at least 6 characters.",
+                    "statusCode": 400,
+                }
+            )
+
+        # hash the new password and save it to the user
+        user.password = make_password(new_password)
+        user.save()
+
+        return Response(
+            {
+                "message": "Password reset successfully. You can now sign in.",
+                "statusCode": 200,
+            }
+        )


### PR DESCRIPTION
### Summary

Backend support for password reset has been implemented, resolving issue #50. 

### Rationale

This change introduces the necessary endpoints for users to initiate and complete a password reset, improving account recovery and overall usability.

### Changes Made

* Introduced a new email template for password reset
* Implemented the logic required to handle password reset requests

#### Sent Email Template

A password reset email is generated and sent to the user as part of the process, providing the necessary link or instructions to complete the reset.

<img width="856" height="691" alt="image" src="https://github.com/user-attachments/assets/d0ba4f64-283d-4e46-bced-45924fd8a6b8" />