### PR TITLE
Added tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+name: Run Unit Tests
+
+on:
+  push:
+    branches:
+      - testing
+  pull_request:
+    branches:
+      - testing
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run unit tests only
+        run: pytest -v tests/test_utils.py

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,31 @@
+import pytest
+import requests
+
+# Integration Testing - is_valid_email integrated with the /api/email-test endpoint.
+
+@pytest.fixture
+def base_url():
+    return "http://127.0.0.1:8000"
+
+
+def test_email_valid(base_url):
+    r = requests.get(
+        f"{base_url}/api/email-test/",
+        params={"email": "test@example.com"}
+    )
+    assert r.status_code == 200
+    assert r.json()["valid"] is True
+
+
+def test_email_invalid(base_url):
+    r = requests.get(
+        f"{base_url}/api/email-test/",
+        params={"email": "bad-email"}
+    )
+    assert r.status_code == 200
+    assert r.json()["valid"] is False
+
+
+def test_email_missing(base_url):
+    r = requests.get(f"{base_url}/api/email-test/")
+    assert r.status_code == 400

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import pytest
+from utils.email import is_valid_email
+
+# Unit Testing - is_valid_email for valid emails
+@pytest.mark.parametrize("email", [
+    "test@example.com",
+    "user.name@domain.co",
+    "user_name123@sub.domain.org",
+    "email+tag@gmail.com",
+])
+def test_valid_emails(email):
+    assert is_valid_email(email)
+
+# Unit Testing - is_valid_email for invalid emails
+@pytest.mark.parametrize("email", [
+    "plainaddress",
+    "@missingusername.com",
+    "user@.com",
+    "user@com",
+    "user@domain,com",
+])
+def test_invalid_emails(email):
+    assert not is_valid_email(email)


### PR DESCRIPTION
## Summary

Added unit and integration tests for email validation functionality.

## Changes Made

* Added unit tests for `is_valid_email`

  * Tests multiple valid email formats
  * Tests multiple invalid email formats
  * Uses `pytest.mark.parametrize` for cleaner test coverage

* Added integration tests for `/api/email-test/`

  * Verifies valid email responses
  * Verifies invalid email responses
  * Verifies behavior when email parameter is missing

## Testing

Tested using `pytest`.

Integration tests require the API server to be running locally on:

```bash
http://127.0.0.1:8000
```

## Notes

This PR improves validation reliability and helps ensure consistent API behavior for email validation endpoints.
